### PR TITLE
Add a function to automatically decompress GZIP resources

### DIFF
--- a/src/cavia/core.clj
+++ b/src/cavia/core.clj
@@ -234,14 +234,14 @@
   (let [f    (resource profile id)
         dl-f (resource-download profile id)
         uv-f (resource-unverified profile id)
-        {:keys [url sha1 auth pack]} (resource-info profile id)]
+        {:keys [url sha1 auth packed]} (resource-info profile id)]
     (when *verbose*
       (println (format "Retrieving %s from %s" id url)))
     (condp #(%1 %2) (:protocol (c-url/url url))
       #{"http" "https"} (dl/http-download! url dl-f :auth auth)
       #{"ftp"}          (dl/ftp-download! url dl-f :auth auth)
       (throw (java.net.MalformedURLException. "Unsupported protocol")))
-    (case pack
+    (case packed
       :gzip (do (dc/decompress-gzip dl-f uv-f)
                 (fs/delete dl-f))
       (fs/rename dl-f uv-f))

--- a/src/cavia/core.clj
+++ b/src/cavia/core.clj
@@ -242,7 +242,8 @@
       #{"ftp"}          (dl/ftp-download! url dl-f :auth auth)
       (throw (java.net.MalformedURLException. "Unsupported protocol")))
     (case pack
-      :gzip (dc/decompress-gzip dl-f uv-f)
+      :gzip (do (dc/decompress-gzip dl-f uv-f)
+                (fs/delete dl-f))
       (fs/rename dl-f uv-f))
     (let [act-sha1 (sha1-file uv-f)]
       (if (= act-sha1 sha1)

--- a/src/cavia/core.clj
+++ b/src/cavia/core.clj
@@ -4,7 +4,8 @@
             [me.raynes.fs :as fs]
             [pandect.core :refer [sha1-file]]
             [cavia.common :refer :all]
-            [cavia.downloader :as dl])
+            [cavia [downloader :as dl]
+                   [decompressor :as dc]])
   (:import java.io.File))
 
 (def skeleton-profile {:download-to ".cavia"})
@@ -233,14 +234,16 @@
   (let [f    (resource profile id)
         dl-f (resource-download profile id)
         uv-f (resource-unverified profile id)
-        {:keys [url sha1 auth]} (resource-info profile id)]
+        {:keys [url sha1 auth pack]} (resource-info profile id)]
     (when *verbose*
       (println (format "Retrieving %s from %s" id url)))
     (condp #(%1 %2) (:protocol (c-url/url url))
       #{"http" "https"} (dl/http-download! url dl-f :auth auth)
       #{"ftp"}          (dl/ftp-download! url dl-f :auth auth)
       (throw (java.net.MalformedURLException. "Unsupported protocol")))
-    (fs/rename dl-f uv-f)
+    (case pack
+      :gzip (dc/decompress-gzip dl-f uv-f)
+      (fs/rename dl-f uv-f))
     (let [act-sha1 (sha1-file uv-f)]
       (if (= act-sha1 sha1)
         (fs/rename uv-f f)

--- a/src/cavia/decompressor.clj
+++ b/src/cavia/decompressor.clj
@@ -1,0 +1,15 @@
+(ns cavia.decompressor
+  (:import [java.io FileInputStream FileOutputStream]
+           [java.util.zip GZIPInputStream]))
+
+(def ^:const buf-size 4096)
+
+(defn decompress-gzip
+  [in-f out-f]
+  (let [buffer (byte-array buf-size)]
+    (with-open [in (GZIPInputStream. (FileInputStream. ^String in-f))
+                out (FileOutputStream. ^String out-f)]
+      (loop [len (.read in buffer)]
+        (when (pos? len)
+          (.write out buffer 0 len)
+          (recur (.read in buffer)))))))

--- a/src/cavia/downloader.clj
+++ b/src/cavia/downloader.clj
@@ -3,7 +3,8 @@
             [clj-http.lite.client :as client]
             [cemerick.url :as c-url]
             [progrock.core :as pr]
-            [cavia.common :refer :all])
+            [cavia.common :refer :all]
+            [cavia.util :refer [str->int]])
   (:import [java.io InputStream OutputStream]
            java.net.URLDecoder
            [org.apache.commons.net.ftp FTP FTPClient FTPSClient FTPReply]))
@@ -33,7 +34,7 @@
                         {(keyword (str (name type) "-auth")) [user password]}))
         response (client/get url option)
         content-len (if-let [content-len (get-in response [:headers "content-length"])]
-                      (Integer. ^String content-len) -1)
+                      (str->int ^String content-len) -1)
         is (:body response)]
     (with-open [os (io/output-stream f)]
       (download! is os content-len))))

--- a/src/cavia/util.clj
+++ b/src/cavia/util.clj
@@ -1,0 +1,9 @@
+(ns cavia.util)
+
+(defn str->int [s]
+  (if-not (nil? s)
+    (try
+      (let [[n _ _] (re-matches #"(|-|\+)(\d+)" s)]
+        (Integer. ^String n))
+      (catch NumberFormatException e
+        (Long. ^String s)))))

--- a/test/cavia/core_test.clj
+++ b/test/cavia/core_test.clj
@@ -14,7 +14,7 @@
                {:id :test-resource-gzip
                 :url "https://www.gnu.org/software/emacs/manual/ps/elisp.ps.gz"
                 :sha1 "15aed8831dd42a196288df838793f30b2587fa61"
-                :pack :gzip}]})
+                :packed :gzip}]})
 
 ;;;
 ;;; Setup and teardown

--- a/test/cavia/core_test.clj
+++ b/test/cavia/core_test.clj
@@ -10,7 +10,11 @@
                 :sha1 "42b1e4f531273ea38caaa8c0b1f8da554aa0739b"}
                {:id :test-resource2
                 :url "http://clojure.org/images/clojure-logo-120b.png"
-                :sha1 "unverifiedsha1"}]})
+                :sha1 "unverifiedsha1"}
+               {:id :test-resource-gzip
+                :url "https://www.gnu.org/software/emacs/manual/ps/elisp.ps.gz"
+                :sha1 "15aed8831dd42a196288df838793f30b2587fa61"
+                :pack :gzip}]})
 
 ;;;
 ;;; Setup and teardown
@@ -49,3 +53,9 @@
     (is (cavia/valid? :test-resource)))
   (testing "returns false if the file's hash is invalid"
     (is (not (cavia/valid? :test-resource2)))))
+
+(deftest gzip-test
+  (testing ""
+    (is (cavia/exist? :test-resource-gzip)))
+  (testing ""
+    (is (cavia/valid? :test-resource-gzip))))


### PR DESCRIPTION
This PR adds a function to automatically decompress GZIP resources.
You can specify the decompression behavior using `:pack` key in cavia's profile.

Also, this PR contains a patch that fixes an integer overflow issue around handing content-length.
