### PR TITLE
Java 9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: clojure
-lein: lein2
+lein: 2.8.0
 jdk:
   - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
   - openjdk7
-script: lein2 with-profile dev:1.6:1.8:1.9 test
+script: lein with-profile dev:1.6:1.8:1.9 test

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [commons-net "3.6"]
                  [digest "1.4.5"]
                  [progrock "0.1.2"]]
-  :profiles {:1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]]}
+  :profiles {:1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta2"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :signing {:gpg-key "roimisia@gmail.com"})

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-http-lite "0.3.0"]
+                 [clj-http "3.7.0"]
                  [com.cemerick/url "0.1.1"]
                  [commons-net "3.6"]
                  [digest "1.4.5"]

--- a/src/cavia/downloader.clj
+++ b/src/cavia/downloader.clj
@@ -1,6 +1,6 @@
 (ns cavia.downloader
   (:require [clojure.java.io :as io]
-            [clj-http.lite.client :as client]
+            [clj-http.client :as client]
             [cemerick.url :as c-url]
             [progrock.core :as pr]
             [cavia.common :refer :all]


### PR DESCRIPTION
[`clj-http-lite`](https://github.com/hiredman/clj-http-lite) [uses `javax.xml.bind.DatatypeConverter`](https://github.com/hiredman/clj-http-lite/blob/c0a4645159a742509091e4a088d8a34dbc1f2257/src/clj_http/lite/util.clj#L33)  which is [deprecated for removal](http://download.java.net/java/jdk9/docs/api/java.xml.bind-summary.html) since java 9.

This PR replaces [`clj-http-lite`](https://github.com/hiredman/clj-http-lite) with [`clj-http`](https://github.com/dakrone/clj-http) to avoid `ClassNotFoundException`.

Thank you in advance.