### PR TITLE
Ignore failure of FTP MLST command.

### DIFF
--- a/src/cavia/downloader.clj
+++ b/src/cavia/downloader.clj
@@ -5,7 +5,7 @@
             [progrock.core :as pr]
             [cavia.common :refer :all]
             [cavia.util :refer [str->int]])
-  (:import [java.io InputStream OutputStream]
+  (:import [java.io InputStream OutputStream IOException]
            java.net.URLDecoder
            [org.apache.commons.net.ftp FTP FTPClient FTPSClient FTPReply]))
 
@@ -85,7 +85,7 @@
         (.setDataTimeout 30000)
         (.enterLocalPassiveMode))
       (let [u (c-url/url url)
-            content-len (.. client* (mlistFile (:path u)) getSize)]
+            content-len (try (.. client* (mlistFile (:path u)) getSize) (catch IOException _ -1))]
         (with-open [is ^InputStream (.retrieveFileStream client* (:path u))
                     os (io/output-stream f)]
           (download! is os content-len)))


### PR DESCRIPTION
#### Summary
Don't show progress for FTP download when MLST failed.

#### Problem
Can't download `ftp://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz` because of `org.apache.commons.net.MalformedServerReplyException`.

#### Cause
cavia uses MLST to fetch file size for FTP downloading which is one of the extensions for FTP [RFC3659](https://tools.ietf.org/html/rfc3659). 

```
C> MLst cap60.pl198.tar.gz
S> 250- Listing cap60.pl198.tar.gz
S>  Type=file;Size=1024990;Perm=r; /tmp/cap60.pl198.tar.gz
S> 250 End
```

> The facts are a series of keyword=value pairs each followed by semi-colon (";") characters.

> Notice that the fact line is indented by a single space.  Notice also that there are no spaces in the set of facts returned, until the single space before the file name.

But there seem to be some FTP servers that don't conform to the spec.

```
MLST /goldenPath/hg38/bigZips/hg38.fa.gz
250-Start of list for /goldenPath/hg38/bigZips/hg38.fa.gz
250-modify=20140116051412;perm=adfr;size=983659424;type=file;unique=FD06U39004DC43B;UNIX.group=50;UNIX.mode=0444;UNIX.owner=14; /goldenPath/hg38/bigZips/hg38.fa.gz
250 End of list
```

commons-net [checks the indentation](https://github.com/apache/commons-net/blob/1863723f01e10e3930def14b89e12322bc6f9217/src/main/java/org/apache/commons/net/ftp/FTPClient.java#L2514-L2516) and throws the exception.

This checking is introduced in [this commit](https://github.com/apache/commons-net/commit/d5c724671fd72d49ec416e7fd086220ef7c8f4e2) for 3.6. ([JIRA](https://issues.apache.org/jira/browse/NET-610))

#### Changes
Catch the IOException for MLST and return negative value instead.