### PR TITLE
Bump up commons-compress to 1.26.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [commons-net "3.10.0"]
                  [digest "1.4.10"]
                  [lambdaisland/uri "1.19.155"]
-                 [org.apache.commons/commons-compress "1.25.0"]
+                 [org.apache.commons/commons-compress "1.26.2"]
                  [progrock "0.1.2"]]
   :test-selectors {:default (complement :integration)
                    :integration :integration}


### PR DESCRIPTION
I found the latest cavia contains vulnerabilities below:

- https://nvd.nist.gov/vuln/detail/CVE-2024-25710
- https://nvd.nist.gov/vuln/detail/CVE-2024-26308

This commit passed tests on my machine. Tell me anything if this PR contains any flaws 🙏 