### PR TITLE
Update aws-api to 0.8.735

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17', '21']
+        java: ['11', '17', '21']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: cljdeps-
 
       - name: Run tests
-        run: lein with-profile +1.9:+1.10:+1.11:+1.12 test
+        run: lein with-profile +1.10:+1.11:+1.12 test
 
   get-version:
     needs: [test]

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 ;; Only for the git dependency of tools.deps
-{:deps {com.cognitect.aws/api {:mvn/version "0.8.692"}
-        com.cognitect.aws/endpoints {:mvn/version "871.2.30.11"}
-        com.cognitect.aws/s3 {:mvn/version "871.2.30.11"}
+{:deps {com.cognitect.aws/api {:mvn/version "0.8.735"}
+        com.cognitect.aws/endpoints {:mvn/version "871.2.30.22"}
+        com.cognitect.aws/s3 {:mvn/version "871.2.30.22"}
         com.github.mwiede/jsch {:mvn/version "0.2.24"}
         commons-net/commons-net {:mvn/version "3.11.1"}
         lambdaisland/uri {:mvn/version "1.19.155"}

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/totakke/cavia"
   :license {:name "The MIT License"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[com.cognitect.aws/api "0.8.692"]
-                 [com.cognitect.aws/endpoints "871.2.30.11"]
-                 [com.cognitect.aws/s3 "871.2.30.11"]
+  :dependencies [[com.cognitect.aws/api "0.8.735"]
+                 [com.cognitect.aws/endpoints "871.2.30.22"]
+                 [com.cognitect.aws/s3 "871.2.30.22"]
                  [com.github.mwiede/jsch "0.2.24"]
                  [commons-net "3.11.1"]
                  [lambdaisland/uri "1.19.155"]

--- a/project.clj
+++ b/project.clj
@@ -17,8 +17,7 @@
   :jvm-opts ["-Dclojure.spec.check-asserts=true"]
   :test-selectors {:default (complement :integration)
                    :integration :integration}
-  :profiles {:1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.3"]]}
              :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]]}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"


### PR DESCRIPTION
I've updated aws-api to 0.8.735.

The support for Java 8 and Clojure 1.9 is dropped because the latest aws-api does not support them by default.
The workaround to access localhost minio is included.